### PR TITLE
Add missing dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,8 @@ setuptools.setup(
         'matplotlib',
         'findiff',
         'dill',
-        'parameter-sherpa'
+        'parameter-sherpa',
+        'ipyparallel'
     ],
     python_requires='>=3.6',
     test_suite='nose.collector',


### PR DESCRIPTION
I discovered that the package is currently missing a dependency on `ipyparallel`. (the story: my python installation broke for no apparent reason, so I reinstalled it, and discovered the missing dependency when I tried using the package)