### PR TITLE
require older version of networkx

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
     ],
     install_requires=[
         'numpy',
-        'networkx',
+        'networkx>=2.7,<3.0',
         'scipy',
         'numdifftools',
         'matplotlib',


### PR DESCRIPTION
The newest versions of networkx (3.1, at least) makes some things in our code break. At some point we should update the code, but in the meantime the requriements should at least specify an older version.